### PR TITLE
Fix script execution.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ the following code runs `deno --allow-net example.ts` which is located in `/some
 
 
 ```bash
-/some/work/dir$ deno --allow-run --allow-read https://deno.land/x/rhinoder@v1.2.0/mod.ts --allow-net example.ts
+/some/work/dir$ deno run --allow-run --allow-read https://deno.land/x/rhinoder@v1.2.0/mod.ts --allow-net example.ts
 ```
 
 ## Thanks to

--- a/mod.ts
+++ b/mod.ts
@@ -1,5 +1,5 @@
 function startProcess(args: string[] = []): Deno.Process {
-  return Deno.run({ cmd: ['deno', ...args] });
+  return Deno.run({ cmd: ['deno', 'run', ...args] });
 }
 
 const throttle = 500;


### PR DESCRIPTION
According to the original README.md the way you run this script is the following:
```bash
deno --allow-run --allow-read https://deno.land/x/rhinoder@v1.2.0/mod.ts --allow-net example.ts
```
It however throws this error:
```error: Found argument '--allow-run' which wasn't expected, or isn't valid in this context```

Adding _run_ to the script fixes this.

```
deno --version
deno 1.1.3
v8 8.5.216
typescript 3.9.2
```